### PR TITLE
Upgrade chart.js to 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,30 +158,9 @@
       }
     },
     "chart.js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-      "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
-    },
-    "chartjs-color": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "requires": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.5.0.tgz",
+      "integrity": "sha512-J1a4EAb1Gi/KbhwDRmoovHTRuqT8qdF0kZ4XgwxpGethJHUdDrkqyPYwke0a+BuvSeUxPf8Cos6AX2AB8H8GLA=="
     },
     "chokidar": {
       "version": "3.4.0",
@@ -203,6 +182,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       },
@@ -210,14 +190,10 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         }
       }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "commander": {
       "version": "2.20.3",
@@ -372,11 +348,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "chart.js": "^2.9.4"
+    "chart.js": "^3.5.0"
   }
 }

--- a/src/Base.svelte
+++ b/src/Base.svelte
@@ -1,30 +1,28 @@
 <script>
   import {onMount, afterUpdate, onDestroy} from 'svelte';
   import {clean} from './utils';
-
-  import Chart from 'chart.js';
+  import {Chart, registerables} from 'chart.js';
+  Chart.register(...registerables);
 
   //  Expected data
   export let data = {
     labels: [],
     datasets: [
-      {values: []}
+      {data: []}
     ],
     yMarkers: {},
     yRegions: [],
   };
   export let type = 'line';
   export let options = {};
-  export let plugins = {};
   let chart = null;
   let chartRef;
-  let props = clean($$props, ["data", "type", "options", "plugins"]);
+  let props = clean($$props, ["data", "type", "options"]);
   onMount(() => {
     chart = new Chart(chartRef, {
       type,
       data,
-      options,
-      plugins
+      options
     });
   });
   afterUpdate(() => {
@@ -33,7 +31,6 @@
     chart.data = data;
     chart.type = type;
     chart.options = options;
-    chart.plugins = plugins;
     chart.update()
   });
 


### PR DESCRIPTION
This PR updates the Chart.js library to 3.5 [following the migration guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html). This is a breaking change for `svelte-chartjs` consumers as:

1.  The datapoints in data are now stored in `data` property (compared to `values` previously)
2. Plugin loading is now done by [the registry](https://www.chartjs.org/docs/latest/api/interfaces/Registry.html) and I didn't see a straightforward way to implement it here

Let me know what you think :) 