### PR TITLE
Changed import path, for building in SvelteKit

### DIFF
--- a/src/Base.svelte
+++ b/src/Base.svelte
@@ -1,7 +1,7 @@
 <script>
   import {onMount, afterUpdate, onDestroy} from 'svelte';
   import {clean} from './utils';
-  import {Chart, registerables} from 'chart.js';
+  import {Chart, registerables} from 'chart.js/dist/chart.esm';
   Chart.register(...registerables);
 
   //  Expected data


### PR DESCRIPTION
Importing from the base chart.js package was causing a build error in SvelteKit.  I updated the import path to use the esm module explicitly, which allowed SvelteKit to build properly.

- In the Base.svelte component, I changed the import path to use the esm module. This has been tested with the SvelteKit static adapter (https://github.com/sveltejs/kit/tree/master/packages/adapter-static)