### PR TITLE
Cleaner import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i svelte-chartjs
 ### Usage
 ```svelte
 <script>
-  import Line from "svelte-chartjs/src/Line.svelte"
+  import { Line } from "svelte-chartjs"
 </script>
 <Line data={...} />
 ```


### PR DESCRIPTION
Since the ``index.js`` exports the charts components, I think it's cleaner if the example suggest to import directly from the package instead of from the ``src`` folder.