### PR TITLE
chore(exports): add exports to package.json for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,11 @@
     "vite": "^4.0.5",
     "vitest": "^0.27.0",
     "vitest-canvas-mock": "^0.2.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/types/index.ts",
+      "svelte": "./src/index.ts"
+    }
   }
 }


### PR DESCRIPTION
This resolves the issue: 

> [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-chartjs@3.1.2