### PR TITLE
refactor(sandboxes): update package.json for each sample to use latest source

### DIFF
--- a/sandboxes/bar/package.json
+++ b/sandboxes/bar/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/bubble/package.json
+++ b/sandboxes/bubble/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/doughnut/package.json
+++ b/sandboxes/doughnut/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/events/package.json
+++ b/sandboxes/events/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/line/package.json
+++ b/sandboxes/line/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/pie/package.json
+++ b/sandboxes/pie/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/pie/vite.config.js
+++ b/sandboxes/pie/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+});

--- a/sandboxes/polar/package.json
+++ b/sandboxes/polar/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/radar/package.json
+++ b/sandboxes/radar/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/ref/package.json
+++ b/sandboxes/ref/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {

--- a/sandboxes/scatter/package.json
+++ b/sandboxes/scatter/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "svelte": "^4.0.0",
-    "svelte-chartjs": "^3.0.0",
+    "svelte-chartjs": "../../",
     "chart.js": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I made the change that produces the smallest diff. You could also create an alias inside vite, but this does the same thing.

```js
import { defineConfig } from 'vite';
import { svelte } from '@sveltejs/vite-plugin-svelte';
import path from 'path';

export default defineConfig({
  plugins: [svelte()],
  resolve: {
    alias: {
      'svelte-chartjs': path.resolve(__dirname, '../../')
    }
  }
});
```