### PR TITLE
fix(exports): update types path to use the correct type def

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "chartjs"
   ],
   "type": "module",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js",
       "import": "./dist/index.js"
     },


### PR DESCRIPTION
Updates the `types` export path to use the correct type def file

Fixes #143 